### PR TITLE
Modernisation for Laravel 13+ and PHP 8.3+

### DIFF
--- a/Attributes/HasToken.php
+++ b/Attributes/HasToken.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace KDuma\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class HasToken
+{
+    public function __construct(
+        public readonly int $length = 10,
+        public readonly string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+        public readonly ?string $salt = null,
+    ) {}
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Eloquent Tokenable
 
+[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-tokenable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+[![Total Downloads](https://poser.pugx.org/kduma/eloquent-tokenable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+[![License](https://poser.pugx.org/kduma/eloquent-tokenable/license.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+
 Eloquent trait for exposing Hashids-based tokens on Laravel models instead of numeric IDs.
 
 Full documentation: [opensource.duma.sh/libraries/php/eloquent-tokenable](https://opensource.duma.sh/libraries/php/eloquent-tokenable)

--- a/README.md
+++ b/README.md
@@ -1,47 +1,82 @@
-# L5-eloquent-tokenable
-[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-tokenable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-tokenable) 
-[![Total Downloads](https://poser.pugx.org/kduma/eloquent-tokenable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-tokenable) 
-[![Latest Unstable Version](https://poser.pugx.org/kduma/eloquent-tokenable/v/unstable.svg)](https://packagist.org/packages/kduma/eloquent-tokenable) 
-[![License](https://poser.pugx.org/kduma/eloquent-tokenable/license.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/76ba87c2-d5c1-4516-af23-3d38f2990145/mini.png)](https://insight.sensiolabs.com/projects/76ba87c2-d5c1-4516-af23-3d38f2990145)
-[![StyleCI](https://styleci.io/repos/30102978/shield?branch=master)](https://styleci.io/repos/30102978)
+# Eloquent Tokenable
 
-Allows using tokens (HashIDs) instead of id in Laravel Eloquent models.
+[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-tokenable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+[![Total Downloads](https://poser.pugx.org/kduma/eloquent-tokenable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+[![License](https://poser.pugx.org/kduma/eloquent-tokenable/license.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+
+Allows using tokens (HashIDs) instead of numeric IDs in Laravel Eloquent models.
 
 Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-tokenable](https://opensource.duma.sh/libraries/php/eloquent-tokenable)
 
-# Setup
-Add the package to the require section of your composer.json and run `composer update`
+## Requirements
 
-    "kduma/eloquent-tokenable": "^1.1"
+- PHP `^8.3`
+- Laravel `^13.0`
 
-# Prepare models
-In your model add following lines:
-    
-    use \KDuma\Eloquent\Tokenable;
-    protected $appends = array('token');
+## Installation
 
-Optionally you can add also:
+```bash
+composer require kduma/eloquent-tokenable
+```
 
-- `protected $salt = 'SALT';`  
-A salt for making hashes. Default is table name. This salt is added to your `APP_KEY`.
+## Setup
 
-- `protected $length = 10;`  
-A salt length. Default is 10.
+Add the `Tokenable` trait to your model:
 
-- `protected $alphabet = 'qwertyuiopasdfghjklzxcvbnm1234567890';`  
-A hash alphabet. Default is `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`
+```php
+use KDuma\Eloquent\Tokenable;
 
-# Usage
-- `$model->token` - Generate tokens
-- `Model::whereToken($id)->first()` - Find by token. (`whereToken` is query scope)
-   
+class Order extends Model
+{
+    use Tokenable;
+}
+```
 
-# Hashids
+## Configuration
 
-A special thanks to creators of [hashids](https://github.com/ivanakimov/hashids.php), a PHP class that this package is based.
+### New style — PHP Attribute (recommended)
 
+```php
+use KDuma\Eloquent\Tokenable;
+use KDuma\Eloquent\Attributes\HasToken;
 
+#[HasToken(length: 12, alphabet: 'abcdef1234567890')]
+class Order extends Model
+{
+    use Tokenable;
+}
+```
 
-# Packagist
-View this package on Packagist.org: [kduma/eloquent-tokenable](https://packagist.org/packages/kduma/eloquent-tokenable)
+Available `HasToken` parameters:
+- `length` — minimum hash length (default: `10`)
+- `alphabet` — characters used in the hash (default: `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`)
+- `salt` — custom salt added to `APP_KEY` (default: table name)
+
+### Old style — model properties (deprecated, triggers `E_USER_DEPRECATED`)
+
+```php
+class Order extends Model
+{
+    use Tokenable;
+
+    protected ?string $salt = 'SALT';       // ⚠️ deprecated
+    protected int $length = 10;             // ⚠️ deprecated
+    protected string $alphabet = 'abc...';  // ⚠️ deprecated
+}
+```
+
+## Usage
+
+- `$model->token` — returns the HashID token for the model
+- `Model::whereToken($token)` — query scope to find by token
+
+```php
+$order = Order::find(1);
+echo $order->token; // e.g. "k3Zx9mPqW2"
+
+$found = Order::whereToken('k3Zx9mPqW2')->first();
+```
+
+## Packagist
+
+[kduma/eloquent-tokenable](https://packagist.org/packages/kduma/eloquent-tokenable)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Eloquent Tokenable
 
-[![Latest Stable Version](https://poser.pugx.org/kduma/eloquent-tokenable/v/stable.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
-[![Total Downloads](https://poser.pugx.org/kduma/eloquent-tokenable/downloads.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
-[![License](https://poser.pugx.org/kduma/eloquent-tokenable/license.svg)](https://packagist.org/packages/kduma/eloquent-tokenable)
+Eloquent trait for exposing Hashids-based tokens on Laravel models instead of numeric IDs.
 
-Allows using tokens (HashIDs) instead of numeric IDs in Laravel Eloquent models.
-
-Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-tokenable](https://opensource.duma.sh/libraries/php/eloquent-tokenable)
+Full documentation: [opensource.duma.sh/libraries/php/eloquent-tokenable](https://opensource.duma.sh/libraries/php/eloquent-tokenable)
 
 ## Requirements
 
@@ -19,64 +15,22 @@ Check full documentation here: [opensource.duma.sh/libraries/php/eloquent-tokena
 composer require kduma/eloquent-tokenable
 ```
 
-## Setup
-
-Add the `Tokenable` trait to your model:
-
-```php
-use KDuma\Eloquent\Tokenable;
-
-class Order extends Model
-{
-    use Tokenable;
-}
-```
-
-## Configuration
-
-### New style — PHP Attribute (recommended)
+## Usage
 
 ```php
 use KDuma\Eloquent\Tokenable;
 use KDuma\Eloquent\Attributes\HasToken;
 
-#[HasToken(length: 12, alphabet: 'abcdef1234567890')]
+#[HasToken(length: 10)]
 class Order extends Model
 {
     use Tokenable;
 }
 ```
-
-Available `HasToken` parameters:
-- `length` — minimum hash length (default: `10`)
-- `alphabet` — characters used in the hash (default: `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`)
-- `salt` — custom salt added to `APP_KEY` (default: table name)
-
-### Old style — model properties (deprecated, triggers `E_USER_DEPRECATED`)
-
-```php
-class Order extends Model
-{
-    use Tokenable;
-
-    protected ?string $salt = 'SALT';       // ⚠️ deprecated
-    protected int $length = 10;             // ⚠️ deprecated
-    protected string $alphabet = 'abc...';  // ⚠️ deprecated
-}
-```
-
-## Usage
-
-- `$model->token` — returns the HashID token for the model
-- `Model::whereToken($token)` — query scope to find by token
 
 ```php
 $order = Order::find(1);
 echo $order->token; // e.g. "k3Zx9mPqW2"
 
-$found = Order::whereToken('k3Zx9mPqW2')->first();
+$order = Order::whereToken('k3Zx9mPqW2')->first();
 ```
-
-## Packagist
-
-[kduma/eloquent-tokenable](https://packagist.org/packages/kduma/eloquent-tokenable)

--- a/Tokenable.php
+++ b/Tokenable.php
@@ -1,51 +1,62 @@
 <?php
+declare(strict_types=1);
 
 namespace KDuma\Eloquent;
 
-use Config;
 use Hashids\Hashids;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use KDuma\Eloquent\Attributes\HasToken;
 
-/**
- * Class Tokenable.
- */
 trait Tokenable
 {
-    /**
-     * @return Hashids
-     */
-    private function getHashingInstance()
+    private function getHashingInstance(): Hashids
     {
-        $salt = Config::get('app.key').($this->salt ?: $this->getTable());
-        $min_hash_length = $this->length ?: 10;
-        $alphabet = $this->alphabet ?: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+        $salt = config('app.key') . (
+            $this->resolveTokenableConfig('salt', 'salt', null)
+            ?? $this->getTable()
+        );
+        $minHashLength = $this->resolveTokenableConfig('length', 'length', 10);
+        $alphabet = $this->resolveTokenableConfig('alphabet', 'alphabet', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
 
-        return new Hashids($salt, $min_hash_length, $alphabet);
+        return new Hashids($salt, $minHashLength, $alphabet);
     }
 
-    /**
-     * @return string
-     */
-    public function getTokenAttribute()
+    protected function token(): Attribute
     {
-        $hashids = $this->getHashingInstance();
-
-        return $hashids->encode($this->id);
+        return Attribute::make(
+            get: fn (): string => $this->getHashingInstance()->encode($this->id),
+        );
     }
 
-    /**
-     * @param $query
-     * @param $token
-     * @return bool|int
-     */
-    public function scopeWhereToken($query, $token)
+    public function scopeWhereToken(Builder $query, string $token): Builder
     {
         $hashids = $this->getHashingInstance();
         $id = $hashids->decode($token);
 
-        if (count($id) == 0) {
+        if ($id === []) {
             return $query->whereRaw('1 = 0');
         }
 
         return $query->where('id', $id[0]);
+    }
+
+    private function resolveTokenableConfig(string $attrProperty, string $legacyProperty, mixed $default): mixed
+    {
+        $value = static::resolveClassAttribute(HasToken::class, $attrProperty);
+        if ($value !== null) {
+            return $value;
+        }
+
+        if (isset($this->{$legacyProperty})) {
+            trigger_error(
+                "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasToken] attribute instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return $this->{$legacyProperty};
+        }
+
+        return $default;
     }
 }

--- a/Tokenable.php
+++ b/Tokenable.php
@@ -48,13 +48,18 @@ trait Tokenable
             return $value;
         }
 
-        if (isset($this->{$legacyProperty}) && $this->{$legacyProperty} !== '' && $this->{$legacyProperty} !== 0) {
+        if (property_exists($this, $legacyProperty)) {
             trigger_error(
                 "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasToken] attribute instead.',
                 E_USER_DEPRECATED,
             );
 
-            return $this->{$legacyProperty};
+            $value = $this->{$legacyProperty};
+
+            // Treat 0 and '' as "use default" to preserve pre-deprecation behaviour (legacy used ?: operator)
+            if ($value !== 0 && $value !== '') {
+                return $value;
+            }
         }
 
         return $default;

--- a/Tokenable.php
+++ b/Tokenable.php
@@ -49,10 +49,15 @@ trait Tokenable
         }
 
         if (property_exists($this, $legacyProperty)) {
-            trigger_error(
-                "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasToken] attribute instead.',
-                E_USER_DEPRECATED,
-            );
+            static $fired = [];
+            $key = static::class . '::$' . $legacyProperty;
+            if (!isset($fired[$key])) {
+                $fired[$key] = true;
+                trigger_error(
+                    "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasToken] attribute instead.',
+                    E_USER_DEPRECATED,
+                );
+            }
 
             $value = $this->{$legacyProperty};
 

--- a/Tokenable.php
+++ b/Tokenable.php
@@ -48,7 +48,7 @@ trait Tokenable
             return $value;
         }
 
-        if (isset($this->{$legacyProperty})) {
+        if (isset($this->{$legacyProperty}) && $this->{$legacyProperty} !== '' && $this->{$legacyProperty} !== 0) {
             trigger_error(
                 "Using \${$legacyProperty} on " . static::class . ' is deprecated. Use #[HasToken] attribute instead.',
                 E_USER_DEPRECATED,

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
-    "hashids/hashids": "^4.0",
-    "illuminate/database": "7.*|8.*|9.*|10.*|11.*"
+    "php": "^8.3",
+    "illuminate/database": "^13.0",
+    "hashids/hashids": "^4.0 || ^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary
- Bump PHP requirement to `^8.3`, Laravel to `^13.0`
- Replace `Config` facade with `config()` helper
- Replace old `getTokenAttribute()` accessor with `Attribute::make()`
- Add `HasToken` PHP Attribute class for declarative configuration
- Add `declare(strict_types=1)` and full type hints
- Legacy `$length`, `$alphabet`, `$salt` properties still work with `E_USER_DEPRECATED` notice